### PR TITLE
New setting for using unit tags to restrict specific ammo + fixes

### DIFF
--- a/AmmoHolder.cs
+++ b/AmmoHolder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using BattleTech;
 using BattleTech.Data;
 using ShellShuffler.Init;
@@ -9,8 +10,8 @@ namespace ShellShuffler
     {
         private static AmmoHolder _instance;
         public DataManager dataManager;
-        public List <AmmunitionDef> ammoList = new List<AmmunitionDef>();
-        public List <AmmunitionBoxDef> ammoBoxList = new List<AmmunitionBoxDef>();
+        public Dictionary<string, AmmunitionDef> ammoById = new ();
+        public Dictionary<AmmoCategoryValue, List<AmmunitionBoxDef>> ammoBoxesByCategory = new();
 
         public static AmmoHolder AmmoHolderInstance
         {
@@ -24,30 +25,46 @@ namespace ShellShuffler
         internal void Initialize(DataManager dm)
         {
             dataManager = dm;
-            ammoBoxList = new List<AmmunitionBoxDef>();
-            foreach (var t in dataManager.AmmoBoxDefs)
+            ammoBoxesByCategory = new Dictionary<AmmoCategoryValue, List<AmmunitionBoxDef>>();
+            ammoById = new Dictionary<string, AmmunitionDef>();
+            foreach (var ammo in dataManager.AmmoDefs.Where(x => x.Value.Description != null).Select(x => x.Value))
             {
-                if (!t.Value.Description.Id.EndsWith("ContentAmmunitionBoxDef"))
+                if (ammo.AmmoCategoryValue.UsesInternalAmmo)
                 {
-                    if((t.Value.ComponentTags != null) && (t.Value.ComponentTags.ContainsAny(ModInit.modSettings.BlacklistAmmoboxOutTags)))
-                    {
-                        ModInit.modLog.LogMessage($"Skipping Ammo Box Def: {t.Value.Description.Name} due to blacklisted tags");
-                        continue;
-                    }
-                    ammoBoxList.Add(t.Value);
-                    ModInit.modLog.LogMessage($"Added Ammo Box Def: {t.Value.Description.Name} to ammoBoxList with capacity {t.Value.Capacity}");
+                    continue;
                 }
-                else
-                {
-                    ModInit.modLog.LogMessage($"Ammo Box Def: {t.Value.Description.Name} was ContentAmmunitionBoxDef, skipping.");
-                }
+                ammoById.Add(ammo.Description.Id, ammo);
+                ModInit.modLog.LogMessage($"Added Ammo Def: {ammo.Description.Name} to ammoList");
             }
-            ammoList = new List<AmmunitionDef>();
-            foreach (var t in dataManager.AmmoDefs)
-            {
-                ammoList.Add(t.Value);
-                ModInit.modLog.LogMessage($"Added Ammo Def: {t.Value.Description.Name} to ammoList");
 
+            foreach (AmmunitionBoxDef ammunitionBoxDef in dataManager.AmmoBoxDefs.Where(x => x.Value.Description != null).Select(x => x.Value))
+            {
+                if (ammunitionBoxDef.Description.Id.EndsWith("ContentAmmunitionBoxDef"))
+                {
+                    ModInit.modLog.LogMessage($"Ammo Box Def: {ammunitionBoxDef.Description.Name} was ContentAmmunitionBoxDef, skipping.");
+                    continue;
+                }
+
+                if (ammunitionBoxDef.ComponentTags != null && ammunitionBoxDef.ComponentTags.ContainsAny(ModInit.modSettings.BlacklistAmmoboxOutTags))
+                {
+                    ModInit.modLog.LogMessage($"Skipping Ammo Box Def: {ammunitionBoxDef.Description.Name} due to blacklisted tags");
+                    continue;
+                }
+
+                if (!ammoById.TryGetValue(ammunitionBoxDef.AmmoID, out var ammoDef))
+                {
+                    ModInit.modLog.LogMessage($"Skipping Ammo Box Def: Unable to find ammunition {ammunitionBoxDef.AmmoID} for {ammunitionBoxDef.Description.Id}");
+                    continue;
+                }
+
+                if (!ammoBoxesByCategory.TryGetValue(ammoDef.AmmoCategoryValue, out var list) || list == null)
+                {
+                    list = new List<AmmunitionBoxDef>();
+                    ammoBoxesByCategory[ammoDef.AmmoCategoryValue] = list;
+                }
+                list.Add(ammunitionBoxDef);
+
+                ModInit.modLog.LogMessage($"Added Ammo Box Def: {ammunitionBoxDef.Description.Name} to ammoBoxList with ammo category {ammoDef.AmmoCategoryValue?.Name}, weight {ammunitionBoxDef.Tonnage}t and capacity {ammunitionBoxDef.Capacity}");
             }
         }
     }

--- a/ModInit.cs
+++ b/ModInit.cs
@@ -41,7 +41,6 @@ namespace ShellShuffler.Init
         public bool tagSetsUnion = false;
         public float chanceToShuffle = 1f;
         public int unShuffledBins = 1;
-        public int MaxTriesAmount = 10;
         public List<string> blacklistAmmoboxOutTags = new List<string>();
         private TagSet f_BlacklistAmmoboxOutTags = null;
         public TagSet BlacklistAmmoboxOutTags
@@ -67,6 +66,7 @@ namespace ShellShuffler.Init
         public List<string> blackListShuffleOut = new List<string>();
 
         public Dictionary<string, List<string>> mechDefTagAmmoList = new Dictionary<string, List<string>>();
+        public Dictionary<string, List<string>> mechDefTagRestrictedAmmoList = new Dictionary<string, List<string>>();
 
         public Dictionary<string, int> ammoWeight = new Dictionary<string, int>();
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ This mod provides the ability for OpFor ammunition loads to be dynamically rando
 				"Ammunition_LRM_DF"
 			]
 		},
+		"mechDefTagRestrictedAmmoList": {
+			"unit_no_acid_ammo": [
+				"Ammunition_LRM_Acid",
+				"Ammunition_SRM_Acid"
+			],
+			"unit_no_ap_ammo": [
+				"Ammunition_LRM_AP",
+				"Ammunition_SRM_AP"
+			]
+		},
 		"factionAmmoList": {
 			"Marik": [
 				"Ammunition_LRM_PR",
@@ -50,6 +60,12 @@ This mod provides the ability for OpFor ammunition loads to be dynamically rando
 		},
 		"ammoWeight": {
 			"Ammunition_LRM_ER": 50
+		},
+		"blacklistAmmoboxOutTags": {
+		  "NeverShuffleOut"
+		},
+		"blacklistAmmoboxInTags": {
+		  "NeverShuffleIn"
 		}
 	}
   
@@ -76,7 +92,13 @@ This mod provides the ability for OpFor ammunition loads to be dynamically rando
 `blackListShuffleOut` - List<string>, list of ammo Id's for ammo that will never be shuffled <b>out of</b> a unit.
 
 `mechDefTagAmmoList` - Dictionary<List<string>>, units with the matching mechdef/vehicledef tag are restricted to shuffling in of ammos in the corresponding list. Where multiple tags are matched on a unit, the result depends on the value of `tagSetsUnion`. If `tagSetsUnion = false`, the result is an intersect of the ammo lists. For example, given the above settings a mech with both the `unit_role_brawler` and `unit_role_sniper` tags can only shuffle `Ammunition_LRM_ER`. If `tagSetsUnion = true`, the result is a union of the ammo lists. For example, given the above settings a mech with both the `unit_role_brawler` and `unit_role_sniper` tags can shuffle any of `Ammunition_LRM_ER`, `Ammunition_LRM_Bee`, or `Ammunition_LRM_DF`.
+
+`mechDefTagRestrictedAmmoList` - Dictionary<List<string>>, units with the matching mechdef/vehicledef tag are restricted from shuffling in of ammos in the corresponding list.
 	
 `factionAmmoList` - Dictionary<List<string>>, restricts the pool of available ammos based on factionID. Does <b>not</b> override results of `mechDefTagAmmoList`
 
 `ammoWeight` - Dictionary<string, int>, ammos in this list have their chances to be chosen during the shuffle increased by the corresponding factor. All ammos not listed have weight of `1`.
+
+`blacklistAmmoboxOutTags` - any ammunition boxes with a tag in this list will never be shuffled out
+
+`blacklistAmmoboxInTags` - any ammunition boxes with a tag in this list will never be shuffled in

--- a/ShellShuffler.csproj
+++ b/ShellShuffler.csproj
@@ -34,8 +34,8 @@
   <PropertyGroup>
     <!-- avoids IgnoresAccessChecksToAttribute warnings -->
     <PublicizerRuntimeStrategies>Unsafe</PublicizerRuntimeStrategies>
-    <AssemblyVersion>1.1.2.0</AssemblyVersion>
-    <FileVersion>1.1.2.0</FileVersion>
+    <AssemblyVersion>1.1.2.1</AssemblyVersion>
+    <FileVersion>1.1.2.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Krafs.Publicizer" Version="2.2.1" />

--- a/ShellShuffler.csproj
+++ b/ShellShuffler.csproj
@@ -34,8 +34,8 @@
   <PropertyGroup>
     <!-- avoids IgnoresAccessChecksToAttribute warnings -->
     <PublicizerRuntimeStrategies>Unsafe</PublicizerRuntimeStrategies>
-    <AssemblyVersion>1.1.1.1</AssemblyVersion>
-    <FileVersion>1.1.1.1</FileVersion>
+    <AssemblyVersion>1.1.2.0</AssemblyVersion>
+    <FileVersion>1.1.2.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Krafs.Publicizer" Version="2.2.1" />

--- a/ShellShufflerPatches.cs
+++ b/ShellShufflerPatches.cs
@@ -215,7 +215,10 @@ namespace ShellShuffler.Patches
                                     var restrictedAmmo = ModInit.modSettings.mechDefTagRestrictedAmmoList[key];
                                     foreach (var val in restrictedAmmo)
                                     {
-                                        removeDueToTagRestriction.Add(val, key);
+                                        if (!removeDueToTagRestriction.ContainsKey(val))
+                                        {
+                                            removeDueToTagRestriction[val] = key;
+                                        }
                                     }
                                 }
                             }
@@ -256,7 +259,7 @@ namespace ShellShuffler.Patches
                             var ammunitionLookup = alternateAmmunitions.ToDictionary(a => a.Description.Id, a => a);
                             foreach (var ammunitionBoxDef in alternateBoxDefsList)
                             {
-                                if (ammunitionLookup.TryGetValue(ammunitionBoxDef.AmmoID, out var matchedAmmunition))
+                                if (!possibleSelections.ContainsKey(ammunitionBoxDef) && ammunitionLookup.TryGetValue(ammunitionBoxDef.AmmoID, out var matchedAmmunition))
                                 {
                                     ModInit.modLog.LogMessage($"Adding {ammunitionBoxDef.Description.Id} ({ammunitionBoxDef.Tonnage}t) of ammunition {matchedAmmunition.Description.Id} to possible selections");
                                     possibleSelections.Add(ammunitionBoxDef, matchedAmmunition);


### PR DESCRIPTION
- Added new setting for using unit tags to restrict specific ammo from being shuffled in.
- Fixed some minor bugs
- Some refactoring